### PR TITLE
Increase interop of symfony and zend components

### DIFF
--- a/bin/prooph-cli
+++ b/bin/prooph-cli
@@ -8,25 +8,52 @@
  * @license   https://github.com/proophsoftware/prooph-cli/blob/master/LICENSE.md New BSD License
  */
 
-/**
- * This makes our life easier when dealing with paths. Everything is relative to the application root now.
- */
-chdir(dirname(__DIR__));
-
-if (!file_exists('vendor/autoload.php')) {
-    throw new \RuntimeException(
-        'Unable to load application. Run `php composer.phar install`'
+if (version_compare('5.5.0', PHP_VERSION, '>')) {
+    fwrite(
+        STDERR,
+        'This version of prooph-cli requires PHP 5.5; using the latest version of PHP is highly recommended.' . PHP_EOL
     );
+
+    die(1);
 }
 
-// Setup autoloading
-require 'vendor/autoload.php';
+if (!ini_get('date.timezone')) {
+    ini_set('date.timezone', 'UTC');
+}
+
+foreach (
+    array(
+        __DIR__ . '/../../autoload.php',
+        __DIR__ . '/../vendor/autoload.php',
+        __DIR__ . '/vendor/autoload.php'
+    ) as $file
+) {
+    if (file_exists($file)) {
+        define('PROOPHCLI_COMPOSER_INSTALL', $file);
+
+        break;
+    }
+}
+
+unset($file);
+
+if (!defined('PROOPHCLI_COMPOSER_INSTALL')) {
+    fwrite(STDERR,
+        'You need to set up the project dependencies using the following commands:' . PHP_EOL .
+        'wget http://getcomposer.org/composer.phar' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
+
+    die(1);
+}
+
+require PROOPHCLI_COMPOSER_INSTALL;
 
 use Symfony\Component\Console\Application;
 use \Prooph\Cli\Console\Command;
 
 /* @var $container \Zend\ServiceManager\ServiceManager */
-$container = require 'config/services.php';
+$container = require dirname(__DIR__) . '/config/services.php';
 
 $cli = new Application('Prooph Command Line Interface');
 

--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,15 @@
     "prooph"
   ],
   "require": {
-    "php": "~5.5|~7.0",
-    "symfony/console": "^3.0.1",
+    "php": "~5.5 || ~7.0",
+    "symfony/console": "^2.5 || ^3.0",
     "zendframework/zend-code": "^2.6",
     "zendframework/zend-filter": "^2.5",
-    "zendframework/zend-servicemanager" : "^2.6",
+    "zendframework/zend-servicemanager" : "^2.7.2",
     "container-interop/container-interop": "^1.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8|^5.0",
+    "phpunit/phpunit": "^4.8 || ^5.0",
     "fabpot/php-cs-fixer": "^1.11",
     "prooph/event-sourcing": "^4.0"
   },

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -7,19 +7,20 @@
  * @license   https://github.com/proophsoftware/prooph-cli/blob/master/LICENSE.md New BSD License
  */
 
+
+use Zend\ServiceManager\Factory\InvokableFactory;
+
 return [
     'services' => [
         'config' => require __DIR__ . '/config.php',
     ],
-    'invokables' => [
-        \Prooph\Cli\Code\Generator\Aggregate::class => '\Prooph\Cli\Code\Generator\Aggregate',
-        \Prooph\Cli\Code\Generator\Command::class => '\Prooph\Cli\Code\Generator\Command',
-        \Prooph\Cli\Code\Generator\CommandHandler::class => '\Prooph\Cli\Code\Generator\CommandHandler',
-        \Prooph\Cli\Code\Generator\CommandHandlerFactory::class => '\Prooph\Cli\Code\Generator\CommandHandlerFactory',
-        \Prooph\Cli\Code\Generator\Event::class => '\Prooph\Cli\Code\Generator\Event',
-        \Prooph\Cli\Console\Command\GenerateAll::class => \Prooph\Cli\Console\Command\GenerateAll::class,
-    ],
     'factories' => [
+        \Prooph\Cli\Code\Generator\Aggregate::class => InvokableFactory::class,
+        \Prooph\Cli\Code\Generator\Command::class => InvokableFactory::class,
+        \Prooph\Cli\Code\Generator\CommandHandler::class => InvokableFactory::class,
+        \Prooph\Cli\Code\Generator\CommandHandlerFactory::class => InvokableFactory::class,
+        \Prooph\Cli\Code\Generator\Event::class => InvokableFactory::class,
+        \Prooph\Cli\Console\Command\GenerateAll::class => InvokableFactory::class,
         \Prooph\Cli\Console\Command\GenerateAggregate::class
             => '\Prooph\Cli\Console\Container\GenerateAggregateFactory',
         \Prooph\Cli\Console\Command\GenerateCommand::class => '\Prooph\Cli\Console\Container\GenerateCommandFactory',


### PR DESCRIPTION
Symfony Console >= 2.5 is now allowed. Zend ServiceManager 3.0 support is not finished yet, see [issue](https://github.com/zendframework/zend-servicemanager/issues/65). Also the other Zend components must support the Service Manager version 3.0.
