### PR TITLE
Allow zf2 and zf3 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
   "require": {
     "php": "~5.5 || ~7.0",
     "symfony/console": "^2.5 || ^3.0",
-    "zendframework/zend-code": "^2.6",
-    "zendframework/zend-filter": "^2.5",
-    "zendframework/zend-servicemanager" : "^2.7.2",
+    "zendframework/zend-code": "^2.6.2 || ^3.0.1",
+    "zendframework/zend-filter": "^2.6.1 || ^3.0",
+    "zendframework/zend-servicemanager" : "^2.7.5 || ^3.0.3",
     "container-interop/container-interop": "^1.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8 || ^5.0",
+    "phpunit/phpunit": "^4.8 || ^5.2",
     "fabpot/php-cs-fixer": "^1.11",
     "prooph/event-sourcing": "^4.0",
     "prooph/event-store-doctrine-adapter" : "^3.0",

--- a/config/services.php
+++ b/config/services.php
@@ -10,8 +10,10 @@
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 
-// check for v3.0
-if (method_exists('\Zend\ServiceManager\ServiceManager', 'configure')) {
-    return new ServiceManager(require __DIR__ . '/dependencies.php');
-}
-return new ServiceManager(new Config(require __DIR__ . '/dependencies.php'));
+$config = new Config(require __DIR__ . '/dependencies.php');
+
+$serviceManager = new ServiceManager();
+$config->configureServiceManager($serviceManager);
+unset($config);
+
+return $serviceManager;

--- a/src/Code/Generator/AbstractGenerator.php
+++ b/src/Code/Generator/AbstractGenerator.php
@@ -24,7 +24,7 @@ abstract class AbstractGenerator implements Generator
         $interfaces = $this->getImplementedInterfaces();
         $properties = $this->getClassProperties();
         $flags = $this->getClassFlags();
-        $methods = $this->getMethods($name);
+        $methods = $this->getMethods($name, $namespace);
         $traits = $this->getTraits();
         // getUses() must called at the end to allow other methods to add import namespaces directives
         $uses = $this->getUses();
@@ -100,9 +100,10 @@ abstract class AbstractGenerator implements Generator
 
     /**
      * @param string $name
+     * @param string $namespace
      * @return array List of class methods
      */
-    protected function getMethods($name)
+    protected function getMethods($name, $namespace)
     {
         return [];
     }

--- a/src/Code/Generator/AddEventToAggregate.php
+++ b/src/Code/Generator/AddEventToAggregate.php
@@ -33,7 +33,8 @@ class AddEventToAggregate implements ReflectionGenerator
         $fileGenerator = FileGenerator::fromReflectedFileName($reflectionClass->getFileName());
         $fileGenerator->setFilename($reflectionClass->getFileName());
 
-        $fileGenerator->setUse(ltrim($namespace, '\\') . '\\' . $commandName);
+        $namespace = ltrim($namespace, '\\') . '\\';
+        $fileGenerator->setUse($namespace . $commandName);
 
         $classGenerator = $fileGenerator->getClass();
 
@@ -42,7 +43,7 @@ class AddEventToAggregate implements ReflectionGenerator
             $classGenerator->setExtendedClass(substr($classToExtend, strrpos($classToExtend, '\\') + 1));
         }
 
-        $classGenerator->addMethodFromGenerator($this->methodWhenEvent($commandName));
+        $classGenerator->addMethodFromGenerator($this->methodWhenEvent($commandName, $namespace));
 
         return $fileGenerator;
     }
@@ -61,11 +62,11 @@ class AddEventToAggregate implements ReflectionGenerator
      * @param string $name
      * @return MethodGenerator
      */
-    private function methodWhenEvent($name)
+    private function methodWhenEvent($name, $namespace)
     {
         $parameters = [
             new ParameterGenerator(
-                'event', $name
+                'event', '\\' . $namespace . $name
             ),
         ];
 
@@ -78,7 +79,7 @@ class AddEventToAggregate implements ReflectionGenerator
                 'Updates aggregate if event was occurred',
                 null,
                 [
-                    new ParamTag('event', [$name, ]),
+                    new ParamTag('event', [ '\\' . $namespace . $name]),
                 ]
             )
         );

--- a/src/Code/Generator/Aggregate.php
+++ b/src/Code/Generator/Aggregate.php
@@ -29,7 +29,7 @@ class Aggregate extends AbstractGenerator
     /**
      * @inheritDoc
      */
-    protected function getMethods($name)
+    protected function getMethods($name, $namespace)
     {
         return [
             $this->methodAggregateId(),

--- a/src/Code/Generator/CommandHandler.php
+++ b/src/Code/Generator/CommandHandler.php
@@ -45,10 +45,10 @@ class CommandHandler extends AbstractGenerator
     /**
      * @inheritDoc
      */
-    protected function getMethods($name)
+    protected function getMethods($name, $namespace)
     {
         return [
-            $this->methodInvoke($name),
+            $this->methodInvoke($name, $namespace),
         ];
     }
 
@@ -56,15 +56,17 @@ class CommandHandler extends AbstractGenerator
      * Build __invoke method
      *
      * @param string $name
+     * @param $namespace
      * @return MethodGenerator
      */
-    private function methodInvoke($name)
+    private function methodInvoke($name, $namespace)
     {
         $name = ucfirst($name);
+        $namespace = '\\' . $namespace . '\\';
 
         $parameters = [
             new ParameterGenerator(
-                'command', $name
+                'command', $namespace . $name
             ),
         ];
 
@@ -77,7 +79,7 @@ class CommandHandler extends AbstractGenerator
                 'Handle command',
                 null,
                 [
-                    new ParamTag('command', [$name, ]),
+                    new ParamTag('command', [ $namespace . $name]),
                 ]
             )
         );

--- a/src/Code/Generator/CommandHandlerFactory.php
+++ b/src/Code/Generator/CommandHandlerFactory.php
@@ -46,10 +46,10 @@ class CommandHandlerFactory extends AbstractGenerator
     /**
      * @inheritDoc
      */
-    protected function getMethods($name)
+    protected function getMethods($name, $namespace)
     {
         return [
-            $this->methodInvoke($name),
+            $this->methodInvoke($name, $namespace),
         ];
     }
 
@@ -57,14 +57,15 @@ class CommandHandlerFactory extends AbstractGenerator
      * Build __invoke method
      *
      * @param string $name
+     * @param string $namespace
      * @return MethodGenerator
      */
-    private function methodInvoke($name)
+    private function methodInvoke($name, $namespace)
     {
         $name = ucfirst($name);
 
         $parameters = [
-            new ParameterGenerator('container', 'ContainerInterface'),
+            new ParameterGenerator('container', '\Interop\Container\ContainerInterface'),
         ];
         $this->uses[] = 'Interop\Container\ContainerInterface';
 
@@ -80,7 +81,7 @@ class CommandHandlerFactory extends AbstractGenerator
                     new ParamTag(
                         'container',
                         [
-                            'ContainerInterface',
+                            '\Interop\Container\ContainerInterface',
                         ]
                     ),
                     new ReturnTag([$name . 'Handler']),

--- a/src/Console/Container/GenerateAggregateFactory.php
+++ b/src/Console/Container/GenerateAggregateFactory.php
@@ -23,14 +23,14 @@ class GenerateAggregateFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator);
+        return $this($serviceLocator, '');
     }
 
     /**
-     * @param ContainerInterface $container
+     * @inheritdoc
      * @return GenerateEvent
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         return new GenerateAggregate(
             $container->get(AggregateGenerator::class)

--- a/src/Console/Container/GenerateCommandFactory.php
+++ b/src/Console/Container/GenerateCommandFactory.php
@@ -10,6 +10,9 @@
 namespace Prooph\Cli\Console\Container;
 
 use Interop\Container\ContainerInterface;
+use Prooph\Cli\Code\Generator\Command;
+use Prooph\Cli\Code\Generator\CommandHandler;
+use Prooph\Cli\Code\Generator\CommandHandlerFactory;
 use Prooph\Cli\Console\Command\GenerateCommand;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -21,19 +24,19 @@ class GenerateCommandFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator);
+        return $this($serviceLocator, '');
     }
 
     /**
-     * @param ContainerInterface $container
+     * @inheritdoc
      * @return GenerateCommand
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         return new GenerateCommand(
-            $container->get(\Prooph\Cli\Code\Generator\Command::class),
-            $container->get(\Prooph\Cli\Code\Generator\CommandHandler::class),
-            $container->get(\Prooph\Cli\Code\Generator\CommandHandlerFactory::class)
+            $container->get(Command::class),
+            $container->get(CommandHandler::class),
+            $container->get(CommandHandlerFactory::class)
         );
     }
 }

--- a/src/Console/Container/GenerateEventFactory.php
+++ b/src/Console/Container/GenerateEventFactory.php
@@ -22,14 +22,14 @@ class GenerateEventFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator);
+        return $this($serviceLocator, '');
     }
 
     /**
-     * @param ContainerInterface $container
+     * @inheritdoc
      * @return GenerateEvent
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         return new GenerateEvent(
             $container->get(EventGenerator::class)


### PR DESCRIPTION
This allows installation of ZF2 and ZF3 components. Now all type hints are FCQN. This is needed for Zend\Code v3.

We can use it as a patch release (0.1.3), otherwise some components must be updated.
